### PR TITLE
Fix favicon.ico

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,7 +112,7 @@ gulp.task('scripts', function () {
 
 /** Root */
 gulp.task('root', function () {
-  gulp.src('./src/*.*')
+  gulp.src(['./src/*.*', '!./src/favicon.ico'])
     .pipe(replace(/@VERSION@/g, version))
     .pipe(gulp.dest('./dist/'));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-triggers",
-  "version": "2.0.36",
+  "version": "2.1.3",
   "private": true,
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Inside the `root` task, in parallel, two streams are running. See https://github.com/GoogleChrome/css-triggers/blob/master/gulpfile.js#L114

`favicon.ico` is a target of both streams. If the second process were to run after the first one, it would override the _bad_ `favicon.ico` but they run in parallel, which, I think, is the problem.

### Solution
Excluded `favicon.ico` from the first stream ⇒ no conflict ⇒ all good.
fix #27 

See `gulp.src` doc here https://github.com/gulpjs/gulp/blob/master/docs/API.md#gulpsrcglobs-options

PS: bumped it for it to be merged after #26 but will get probably a conflict once one of them is merged anyway. I'll fix it then.