### PR TITLE
 Remove message show when we close filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-triggers",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "engines": {
     "node": ">=0.10.0"

--- a/src/scripts/controller/AppController.js
+++ b/src/scripts/controller/AppController.js
@@ -502,7 +502,7 @@ export default class AppController {
       });
     }
 
-    if (visibleCount === 0) {
+    if (visibleCount === 0 && filterValue !== '') {
       this.noResultsMessage.classList.add('app-main__no-results-message--visible');
       this.noResultsMessage.removeAttribute('aria-hidden');
       this.filterText.textContent = filterValue;


### PR DESCRIPTION
 This commit fixes an unreported issue that if we open up filter and then closes it without any value
supplied or with any value supplied then there is always a message in bottom that 
> *There is no property containing ""*

 which is un-neccessary and un-wanted so by this fix when checking on visibleCount in changeOnFilter we are also checking on if filterValue is "" or empty then hide the message.

**GIF** is better than thousand words so...

Before 
> ![animation](https://cloud.githubusercontent.com/assets/10435209/16849939/6ca2708e-4a1a-11e6-84c7-539f56694c94.gif)

After 
> 
![animation_result](https://cloud.githubusercontent.com/assets/10435209/16849962/87ae5c6c-4a1a-11e6-9351-c7bbd1462110.gif)




