### PR TITLE
Fix Gecko data for transform and opacity: they do not cause paints in Gecko.

### DIFF
--- a/data/gecko.json
+++ b/data/gecko.json
@@ -556,12 +556,12 @@
       "composite": true
     },
     "opacity-change": {
-      "paint": true,
+      "paint": false,
       "layout": false,
       "composite": true
     },
     "opacity-initial": {
-      "paint": true,
+      "paint": false,
       "layout": false,
       "composite": true
     },
@@ -781,13 +781,13 @@
       "composite": true
     },
     "transform-change": {
-      "paint": true,
-      "layout": true,
+      "paint": false,
+      "layout": false,
       "composite": true
     },
     "transform-initial": {
-      "paint": true,
-      "layout": true,
+      "paint": false,
+      "layout": false,
       "composite": true
     },
     "transform-origin-change": {


### PR DESCRIPTION
See issue #21.

Do I need to bump the version in package.json?

I'm not sure how the CLA business works - I assume there is an existing agreement for Mozilla? I'll ask some people on our side.